### PR TITLE
Fix TypeScript example of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ test('flushPromises', async () => {
 ## TypeScript
 
 ```ts
-import * as flushPromises from "flush-promises";
+import flushPromises from "flush-promises";
 
 test("flushPromises", async () => {
   let a;


### PR DESCRIPTION
In my project, below error is occured.

```
    tests/views/Board.spec.ts:74:11 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '{ default: () => Promise<any>; }' ha
s no compatible call signatures.

    74     await flushPromises()
                 ~~~~~~~~~~~~~~~

      tests/views/Board.spec.ts:3:1
        3 import * as flushPromises from 'flush-promises'
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a defau
lt import or import require here instead.
```

This fixes it :+1: